### PR TITLE
fix script path

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -43,4 +43,4 @@ def test_rclone_crontab(host):
     assert rclone_conf.uid == 1000
     assert rclone_conf.gid == 1000
     assert rclone_conf.mode == 0o644
-    assert rclone_conf.content_string == '45 8 * * * /etc/rclone/scripts/some_stub_sh\n' # noqa E501
+    assert rclone_conf.content_string == '45 8 * * * /scripts/some_stub_sh\n' # noqa E501

--- a/templates/crontab.j2
+++ b/templates/crontab.j2
@@ -1,3 +1,3 @@
 {% for entry in rclone_scripts %}
-{{ entry.cron }} {{ rclone_conf_dir }}/scripts/{{ entry.path | basename | replace('.', '_') }}
+{{ entry.cron }} /scripts/{{ entry.path | basename | replace('.', '_') }}
 {% endfor %}


### PR DESCRIPTION
When migrating, I made a mistake and added `/etc/conf_dir` to the scripts which doesn't exist in the container.